### PR TITLE
Add optional resource check and failback

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ This will start rlb on port `:7070` by default and requests like `http://host/ap
 * GET|HEAD `/api/v1/jump/<service>?url=/blah/blah2.mp3` – returns 302 redirect to destination server
 * GET|HEAD `/<service>?url=/blah/blah2.mp3` – same as above
 
+## Failback support (optional)
+
+This allow to check the upstreams health for the requested resource and failback to a predefined servers if request fails. `failback` defined in the config file and in case if non-empty will add an additional `HEAD` request to the final URL. If request returns 200, the request will be passed to the upstream, if not - the result will be assembled from the `failback` + resource. I.e. if `failback` is `http://failback.com/` and resource is `/files/blah.mp3` then the final URL will be `http://failback.com/files/blah.mp3`.
+
 ## Config file format
 
 ```yaml
@@ -60,6 +64,8 @@ service2:
         ping: /rtfiles/rt_podcast480.mp3
         method: GET
         weight: 1
+
+failback: http://archives.radio-t.com/media
 ```
 
 ## Stats

--- a/app/config/params.go
+++ b/app/config/params.go
@@ -19,6 +19,7 @@ type ConfFile struct {
 	NoNode   struct {
 		Message string `yaml:"message"`
 	} `yaml:"no_node"`
+	FailBackURL string `yaml:"failback"`
 }
 
 // Node has a part from config and alive + changed for status monitoring

--- a/app/config/params_test.go
+++ b/app/config/params_test.go
@@ -17,6 +17,7 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, "HEAD", r["test1"][1].Method, "HEAD as explicit method")
 	assert.Equal(t, "GET", r["test1"][2].Method, "GET as explicit method")
 	assert.Equal(t, "blah", conf.NoNode.Message)
+	assert.Equal(t, "http://archive.radio-t.com/media", conf.FailBackURL)
 }
 
 const rlbYaml = `
@@ -49,4 +50,6 @@ services:
 
 no_node:
  message: blah
+
+failback: http://archive.radio-t.com/media
 `

--- a/app/main.go
+++ b/app/main.go
@@ -41,7 +41,7 @@ func main() {
 		log.Printf("[WARN] failed to close %s, %s", opts.Conf, err.Error())
 	}
 
-	pck := picker.NewRandomWeighted(conf.Get(), opts.Refresh, opts.TimeOut)
+	pck := picker.NewRandomWeighted(conf.Get(), opts.Refresh, opts.TimeOut, conf.FailBackURL)
 	server.NewRLBServer(pck, conf.NoNode.Message, opts.StatsURL, opts.Port, revision).Run()
 }
 

--- a/app/main.go
+++ b/app/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"time"
 
 	log "github.com/go-pkgz/lgr"
@@ -41,7 +42,7 @@ func main() {
 		log.Printf("[WARN] failed to close %s, %s", opts.Conf, err.Error())
 	}
 
-	pck := picker.NewRandomWeighted(conf.Get(), opts.Refresh, opts.TimeOut, conf.FailBackURL)
+	pck := picker.NewRandomWeighted(conf.Get(), opts.Refresh, opts.TimeOut, strings.TrimSuffix(conf.FailBackURL, "/"))
 	server.NewRLBServer(pck, conf.NoNode.Message, opts.StatsURL, opts.Port, revision).Run()
 }
 

--- a/app/picker/random_test.go
+++ b/app/picker/random_test.go
@@ -9,10 +9,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/umputun/rlb/app/config"
 )
 
-func TestRandom_Pick(t *testing.T) {
+func TestRandom_PickNoFailBack(t *testing.T) {
 
 	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("request %+v", r)
@@ -49,11 +50,87 @@ func TestRandom_Pick(t *testing.T) {
 			{Server: ts2.URL, Method: "GET", Ping: "/test/good_get1", Weight: 1},
 		},
 	}
-	rw := NewRandomWeighted(config.NodesMap(nmap), time.Second, time.Millisecond*100)
+	rw := NewRandomWeighted(config.NodesMap(nmap), time.Second, time.Millisecond*100, "")
 	time.Sleep(2 * time.Second)
 
 	r, _, err := rw.Pick("test", "/test/good_get1")
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(r, ts1.URL) || strings.HasPrefix(r, ts2.URL))
 	assert.True(t, strings.HasSuffix(r, "/test/good_get1"))
+}
+
+func TestRandom_PickWithFailBack(t *testing.T) {
+
+	calls := 0
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("request %+v", r)
+		if r.Method == "HEAD" {
+			calls++
+			if calls > 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/test/good_get1" {
+			fmt.Fprintln(w, "good get 1")
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/test/good_get2" {
+			fmt.Fprintln(w, "good get 2")
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+
+	defer ts1.Close()
+
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("request %+v", r)
+
+		if r.Method == "HEAD" {
+			calls++
+			if calls > 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if r.Method == "GET" && r.URL.Path == "/test/good_get1" {
+			fmt.Fprintln(w, "good get 1")
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/test/good_get2" {
+			fmt.Fprintln(w, "good get 2")
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts2.Close()
+
+	nmap := map[string][]config.Node{
+		"test": {
+			{Server: ts1.URL, Method: "GET", Ping: "/test/good_get1", Weight: 1},
+			{Server: ts2.URL, Method: "GET", Ping: "/test/good_get1", Weight: 1},
+		},
+	}
+	rw := NewRandomWeighted(config.NodesMap(nmap), time.Second, time.Millisecond*100, "http://archive.example.com/media")
+	time.Sleep(2 * time.Second)
+
+	{
+		r, _, err := rw.Pick("test", "/test/good_get1")
+		assert.NoError(t, err)
+		assert.True(t, strings.HasPrefix(r, ts1.URL) || strings.HasPrefix(r, ts2.URL))
+		assert.True(t, strings.HasSuffix(r, "/test/good_get1"))
+	}
+
+	{
+		r, _, err := rw.Pick("test", "/test/good_get1")
+		assert.NoError(t, err)
+		assert.Equal(t, "http://archive.example.com/media/test/good_get1", r)
+	}
+
 }


### PR DESCRIPTION
the goal is to eliminate redirects to a node without the actual resource. the current version expects all nodes to have all the resources, and a not-found redirect is supposed to be handled by the node itself.

this PR adds an optional `HEAD` request prior to the final redirect and failed request will change the redirect to failback url + requested resource